### PR TITLE
Add survey link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you have a question, or need assistance during class, **please create an issu
 
 ## Give Us Feedback
 
-Please take a moment to complete the class survey at: SURVEY-LINK.
+Please take a moment to complete the class survey at: <https://www.surveymonkey.com/r/M7M9LNL>
 
 ## Scripts for Adding Files
 


### PR DESCRIPTION
It looks like the `githubtraining/training-manual` scripts used to automate the creation of SurveyGizmo surveys and add the survey link to each `caption-this` class repository as they were created. This functionality was removed with githubtraining/training-manual#183 after SurveyGizmo was deprecated.

We now use SurveyMonkey to gather feedback. This Pull Requests replaces the variable previously used by the scripts to add survey links with our new survey link. We use the same link every time, so there is no need to reimplement the automated survey creation.