### PR TITLE
Replacing Learning Lab with Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@
 
 After you have completed this course, you are probably wondering where to go from here:
 
-- [GitHub Learning Lab](https://lab.github.com/): self-paced courses with instant bot-assisted feedback.
+- [GitHub Skills](https://skills.github.com/): self-paced courses powered by GitHub Actions.
 - [Microsoft Learn for GitHub](https://docs.microsoft.com/en-us/learn/github/)
 - [Join the open source community](https://github.com/open-source)


### PR DESCRIPTION
With [deprecation of Learning Lab on Sept 1st 2022](https://github.blog/changelog/2022-09-01-deprecating-learning-lab/), the existing link(s) should point to https://skills.github.com/ for hands-on course work following exercise.